### PR TITLE
fixed typo issue

### DIFF
--- a/0x00-shell_basics/README.md
+++ b/0x00-shell_basics/README.md
@@ -98,7 +98,7 @@ Exercise 19:
   The above will return message "Holberton data" for any offset 0 "HOLBERTON" matches.
   A cool thing to note is that the `file` command is compiling and running the magic file. So there is no need to compile to magic "permanently".
   NOTE: Compiling a magic source file:
-  $ file -C -m filename.mgc
-  This produces the comiled magic file.
-  $ file -i -m filename.mgc *
+  $ file -C -m <filename>.mgc
+  This produces the compiled magic file.
+  $ file -i -m <filename>.mgc *
   This allows you to use the compiled file by specifying its name using the -m switch again.


### PR DESCRIPTION
Hi Phillip ! 

I found a typo issue when reading the README.md in 0x00-shell_basics and I propose you this pull request. 
It should be compiled instead of comiled. 
Also, I suggested to write ```<filename>.mgc``` instead of ```filename.mgc``` to show that it's a placeholder. 

Thanks. And Shalom ! 